### PR TITLE
From root component to active component

### DIFF
--- a/CenterOfMassPoint.py
+++ b/CenterOfMassPoint.py
@@ -1,6 +1,8 @@
 #Mike Aubry (w/ true credit going to Sebastian Morales and Brian Ekins)
-#Description - This Fusion 360 Script allows you to create a construction point where the center of mass is for 
+#Description - This Fusion 360 Script allows you to create a construction point where the center of mass is for
 # the top level component. This is especially useful for balancing applications.
+#
+# Modified by Asgeir Mortensen to use the active component insted of the root.
 
 import adsk.core, adsk.fusion, adsk.cam, traceback
 app = adsk.core.Application.get()
@@ -12,75 +14,85 @@ def run(context):
     try:
         app = adsk.core.Application.get()
         ui = app.userInterface
-        
+
         # Get all components in the active design.
         product = app.activeProduct
         design = adsk.fusion.Design.cast(product)
         title = 'Create Center of Mass Point'
-        
-        
+
+
         if not design:
             ui.messageBox('No active Fusion design', title)
             return
-        
+
         # Get the root component of the active design
         rootComp = design.rootComponent
-        
+
+        try:
+	       	# Pick the actice componet over the root.
+        	activeComp = design.activeComponent
+        except:
+        	activeComp = rootComp
+
         # Get physical properties from component (high accuracy)
-        physicalProperties = rootComp.getPhysicalProperties(adsk.fusion.CalculationAccuracy.HighCalculationAccuracy)
-        
+        physicalProperties = activeComp.getPhysicalProperties(\
+        	adsk.fusion.CalculationAccuracy.HighCalculationAccuracy)
+
         # Get center of mass from physical properties
         cog = physicalProperties.centerOfMass
-        
+
         # Check to see if a base feature named "Center of Gravities" exists.
-        baseFeature = rootComp.features.itemByName('Center of Gravities')
+        baseFeature = activeComp.features.itemByName('Center of Gravities')
         if not baseFeature:
             # Create a new base feature.
-            baseFeature = rootComp.features.baseFeatures.add()
+            baseFeature = activeComp.features.baseFeatures.add()
             baseFeature.name = 'Center of Gravities'
 
             # Begin editing the base feature.
-            baseFeature.startEdit()                
-            
+            baseFeature.startEdit()
+
             # Create a construction point at the COG position.
-            constructionPoints = rootComp.constructionPoints
+            constructionPoints = activeComp.constructionPoints
             pointInput = constructionPoints.createInput()
             pointInput.setByPoint(cog)
             pointInput.targetBaseOrFormFeature = baseFeature
             constPoint = constructionPoints.add(pointInput)
             constPoint.name = 'Center of Gravity'
-            
+
             # End the base feature edit.
             baseFeature.finishEdit()
         else:
             # Check that the "Center of Gravity construction point exists.
-            cogPoint = rootComp.constructionPoints.itemByName('Center of Gravity')
-            
-            # Because of a problem with updating an existing point, this current deletes
-            # the existing point so the code in the "else" is never executed.
+            cogPoint = activeComp.constructionPoints\
+            	.itemByName('Center of Gravity')
+
+            # Because of a problem with updating an existing point,
+            # this current deletes the existing point so the code in the
+            # "else" is never executed.
             if cogPoint:
                 cogPoint.deleteMe()
                 cogPoint = None
-            
+
             if not cogPoint:
                 # Create the construction point.
                 # Begin editing the base feature.
-                baseFeature.startEdit()                
-                
+                baseFeature.startEdit()
+
                 # Create a construction point at the COG position.
-                constructionPoints = rootComp.constructionPoints
+                constructionPoints = activeComp.constructionPoints
                 pointInput = constructionPoints.createInput()
                 pointInput.setByPoint(cog)
                 pointInput.targetBaseOrFormFeature = baseFeature
                 constPoint = constructionPoints.add(pointInput)
                 constPoint.name = 'Center of Gravity'
-                
+
                 # End the base feature edit.
                 baseFeature.finishEdit()
             else:
                 # Edit the existing construction point.
-                pointDef = adsk.fusion.ConstructionPointPointDefinition.cast(cogPoint.definition)
-                baseFeature.startEdit()                
+                pointDef = adsk.fusion.ConstructionPointPointDefinition\
+                	.cast(cogPoint.definition)
+                baseFeature.startEdit()
                 pointDef.pointEntity = cog
                 baseFeature.finishEdit()
     except:


### PR DESCRIPTION
Changed the script to use the active component (if found) instead of the root component, sometimes it's nice to be able to have separate points of mass.

Lots of the lines have been changed as it's common to not have invisible characters without meaning when writing python. I'm also really strict when it comes to line length.

I modified it for my own needs, but one should always share, happy holidays.